### PR TITLE
修复地形改造器在升级时会占用5个可用空间的问题

### DIFF
--- a/src/config/gameConfig.ts
+++ b/src/config/gameConfig.ts
@@ -255,7 +255,7 @@ export const BUILDINGS: Record<BuildingType, BuildingConfig> = {
     baseCost: { metal: 0, crystal: 50000, deuterium: 100000, darkMatter: 0, energy: 0 },
     baseTime: 60,
     costMultiplier: 2,
-    spaceUsage: 5,
+    spaceUsage: 0,
     planetOnly: true,
     requirements: {
       [BuildingType.ResearchLab]: 10,


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 将地形改造器建筑的空间占用设置为 0，以防止其在升级后占用 5 个可用槽位。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Set the terraformer building's space usage to zero to prevent it from occupying five available slots when upgraded.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 将地形改造器建筑的空间占用设置为 0，以防止其在升级后占用 5 个可用槽位。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Set the terraformer building's space usage to zero to prevent it from occupying five available slots when upgraded.

</details>

</details>