### PR TITLE
chore(github-pages): 更新GitHub Pages构建工作流

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,8 +1,10 @@
-name: Deploy Vue Project
+name: 构建Github Pages
 
 on:
   push:
-    branches: [ main ] # 如果你的主分支叫 master，请改为 master
+    branches: [ main ]
+  workflow_dispatch:
+
 
 permissions:
   contents: read


### PR DESCRIPTION
- 将工作流名称从"Deploy Vue Project"更改为"构建Github Pages"
- 添加workflow_dispatch触发器以支持手动触发部署
- 保留main分支的推送触发器
- 维持内容读取权限设置

## Summary by Sourcery

CI：
- 重命名 GitHub Pages 工作流，并添加手动的 `workflow_dispatch` 触发器，同时保持针对 `main` 分支的 push 触发器不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Rename the GitHub Pages workflow and add a manual workflow_dispatch trigger while keeping the main branch push trigger unchanged.

</details>