### PR TITLE
Revert "chore(github-pages): 更新GitHub Pages构建工作流"

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,10 +1,8 @@
-name: 构建Github Pages
+name: Deploy Vue Project
 
 on:
   push:
-    branches: [ main ]
-  workflow_dispatch:
-
+    branches: [ main ] # 如果你的主分支叫 master，请改为 master
 
 permissions:
   contents: read


### PR DESCRIPTION
Reverts setube/ogame-vue-ts#7

## 由 Sourcery 提供的总结

构建：
- 恢复 GitHub Pages 工作流，使其仅在推送到主分支时触发，并将其重命名为通用的 Vue 项目部署工作流。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Restore the GitHub Pages workflow to trigger only on pushes to the main branch and rename it to a generic Vue project deploy workflow.

</details>