### PR TITLE
fix: 补全舰队预设中缺失的4种舰船类型

### DIFF
--- a/src/views/FleetView.vue
+++ b/src/views/FleetView.vue
@@ -652,6 +652,15 @@
   const { SHIPS } = useGameConfig()
   const planet = computed(() => gameStore.currentPlanet)
 
+  // 创建默认空舰队映射
+  const createEmptyFleet = (): Partial<Fleet> => {
+    const fleet: Partial<Fleet> = {}
+    for (const type of Object.values(ShipType)) {
+      fleet[type] = 0
+    }
+    return fleet
+  }
+
   // AlertDialog 状态
   const alertDialogOpen = ref(false)
   const alertDialogTitle = ref('')
@@ -690,19 +699,7 @@
 
   // 跳跃门相关
   const selectedJumpGateTarget = ref<typeof planet.value | null>(null)
-  const jumpGateFleet = ref<Partial<Fleet>>({
-    [ShipType.LightFighter]: 0,
-    [ShipType.HeavyFighter]: 0,
-    [ShipType.Cruiser]: 0,
-    [ShipType.Battleship]: 0,
-    [ShipType.SmallCargo]: 0,
-    [ShipType.LargeCargo]: 0,
-    [ShipType.ColonyShip]: 0,
-    [ShipType.Recycler]: 0,
-    [ShipType.EspionageProbe]: 0,
-    [ShipType.DarkMatterHarvester]: 0,
-    [ShipType.Deathstar]: 0
-  })
+  const jumpGateFleet = ref<Partial<Fleet>>(createEmptyFleet())
 
   // 是否显示跳跃门标签页（当前在月球上且有跳跃门）
   const showJumpGateTab = computed(() => {
@@ -800,19 +797,7 @@
   })
 
   // 选择的舰队
-  const selectedFleet = ref<Partial<Fleet>>({
-    [ShipType.LightFighter]: 0,
-    [ShipType.HeavyFighter]: 0,
-    [ShipType.Cruiser]: 0,
-    [ShipType.Battleship]: 0,
-    [ShipType.SmallCargo]: 0,
-    [ShipType.LargeCargo]: 0,
-    [ShipType.ColonyShip]: 0,
-    [ShipType.Recycler]: 0,
-    [ShipType.EspionageProbe]: 0,
-    [ShipType.DarkMatterHarvester]: 0,
-    [ShipType.Deathstar]: 0
-  })
+  const selectedFleet = ref<Partial<Fleet>>(createEmptyFleet())
 
   // 目标坐标
   const targetPosition = ref({ galaxy: 1, system: 1, position: 1 })
@@ -1008,8 +993,8 @@
   // 加载预设
   const loadPreset = (preset: FleetPreset) => {
     // 加载舰队配置
-    Object.keys(selectedFleet.value).forEach(key => {
-      selectedFleet.value[key as ShipType] = preset.fleet[key as ShipType] || 0
+    Object.values(ShipType).forEach(key => {
+      selectedFleet.value[key] = preset.fleet[key] || 0
     })
 
     // 不再加载坐标，保留用户当前输入的坐标


### PR DESCRIPTION
- 为 selectedFleet 和 jumpGateFleet 初始化补全 Fleet 接口中定义的 Battlecruiser（战列巡洋舰）、Bomber（轰炸机）、Destroyer（驱逐舰）、SolarSatellite（太阳能卫星）4 种舰船
- loadPreset 改为遍历 Object.values(ShipType) 而非仅已初始化的 key，确保所有舰船类型的预设值都能被正确恢复

## 由 Sourcery 提供的概要

在预设中补全缺失的舰队舰船类型，并确保在恢复舰队预设时加载所有已定义的舰船类型。

Bug 修复：
- 将缺失的 Battlecruiser、Bomber、Destroyer 和 SolarSatellite 舰船类型添加到已选舰队预设和跳跃门舰队预设中，以便它们能够正确初始化。
- 通过遍历所有 ShipType 值来加载舰队预设，从而一致地恢复每一种舰船类型，而不仅仅是那些在舰队状态中预先初始化的类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Complete missing fleet ship types in presets and ensure all defined ship types are loaded when restoring fleet presets.

Bug Fixes:
- Add missing Battlecruiser, Bomber, Destroyer, and SolarSatellite ship types to selected and jump gate fleet presets so they are initialized correctly.
- Load fleet presets by iterating over all ShipType values to restore every ship type consistently, not only those pre-initialized in the fleet state.

</details>